### PR TITLE
seo: add SEO/UX-optimised landing page for GitHub Pages

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -7,3 +7,4 @@
 - License reconciliation verified on 2026-06-26: `LICENSE` is Creative Commons Attribution-ShareAlike 4.0 International and `CITATION.cff` declares `CC-BY-SA-4.0`; stale GPL mismatch notes were documentation drift.
 ## ✅ Completed (Recent only)
 - 2026-06-26: Updated `README.md` and `CLAUDE.md` to remove obsolete GPL mismatch text and reflect CC BY-SA 4.0 alignment.
+- 08-07-2026: /cologne-pages-landing — SEO landing + .nojekyll live

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Kṛdantarūpamālā (KRM) · Cologne Digital Sanskrit Lexicon</title>
+<meta name="description" content="A Sanskrit grammatical handbook of kṛdanta (primary derivative / participial) verb forms, attributed to Bhaṭṭoji Dīkṣita — a systematic reference for Sanskrit verbal derivatives.">
+<link rel="canonical" href="https://sanskrit-lexicon.github.io/KRM/">
+<meta name="theme-color" content="#1f78b4">
+<meta name="author" content="Bhaṭṭoji Dīkṣita (attrib.)">
+<meta name="robots" content="index,follow">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Cologne Digital Sanskrit Lexicon">
+<meta property="og:locale" content="en">
+<meta property="og:title" content="Kṛdantarūpamālā (KRM)">
+<meta property="og:description" content="A Sanskrit grammatical handbook of kṛdanta (primary derivative / participial) verb forms, attributed to Bhaṭṭoji Dīkṣita — a systematic reference for Sanskrit verbal derivatives.">
+<meta property="og:url" content="https://sanskrit-lexicon.github.io/KRM/">
+<meta property="og:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Cologne Digital Sanskrit Lexicon">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Kṛdantarūpamālā (KRM)">
+<meta name="twitter:description" content="A Sanskrit grammatical handbook of kṛdanta (primary derivative / participial) verb forms, attributed to Bhaṭṭoji Dīkṣita — a systematic reference for Sanskrit verbal derivatives.">
+<meta name="twitter:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Book","name":"Kṛdantarūpamālā","alternateName":"KRM","inLanguage":"sa","publisher":{"@type":"Organization","name":"Cologne Digital Sanskrit Lexicon"},"url":"https://sanskrit-lexicon.github.io/KRM/","isAccessibleForFree":true,"license":"https://creativecommons.org/licenses/by-sa/4.0/"}
+</script>
+<style>
+  :root { --ink:#1b2a38; --muted:#5a6b7a; --accent:#1f78b4; --bg:#f7f9fb; --card:#fff; --line:#e2e8ee; }
+  * { box-sizing:border-box; }
+  html { -webkit-text-size-adjust:100%; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    color:var(--ink); background:var(--bg); line-height:1.6; }
+  a { color:var(--accent); }
+  .wrap { max-width:760px; margin:0 auto; padding:0 20px; }
+  header.top { border-bottom:1px solid var(--line); background:var(--card); }
+  header.top .wrap { display:flex; align-items:center; gap:.5rem; height:56px; font-size:.95rem; }
+  header.top a { color:var(--muted); text-decoration:none; font-weight:600; }
+  .hero { background:linear-gradient(160deg,#1e2f40,#2d4e6e); color:#f4f7fa; padding:56px 0 48px; }
+  .badge { display:inline-block; font-weight:700; letter-spacing:.08em; font-size:.8rem;
+    background:rgba(255,255,255,.14); color:#cfe3f2; padding:.35rem .7rem; border-radius:999px; }
+  .hero h1 { font-family:Georgia,"Times New Roman",serif; font-size:2.1rem; line-height:1.2; margin:.9rem 0 .5rem; }
+  .hero .sub { color:#b7cddf; font-size:1.05rem; margin:0 0 1.2rem; }
+  .hero p.desc { color:#dbe6f0; margin:0; max-width:62ch; }
+  .cta { display:flex; flex-wrap:wrap; gap:.7rem; margin:1.6rem 0 0; }
+  .btn { display:inline-block; padding:.7rem 1.1rem; border-radius:8px; text-decoration:none; font-weight:600; font-size:.95rem; }
+  .btn.primary { background:#4aa3df; color:#0b1b28; }
+  .btn.ghost { background:rgba(255,255,255,.10); color:#eaf2f8; border:1px solid rgba(255,255,255,.25); }
+  main { padding:40px 0 20px; }
+  .facts { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
+    background:var(--line); border:1px solid var(--line); border-radius:10px; overflow:hidden; margin:0 0 28px; }
+  .facts div { background:var(--card); padding:14px 16px; }
+  .facts dt { font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); }
+  .facts dd { margin:.2rem 0 0; font-weight:600; }
+  section h2 { font-size:1.15rem; margin:1.8rem 0 .5rem; }
+  .note { color:var(--muted); font-size:.95rem; }
+  footer { border-top:1px solid var(--line); background:var(--card); margin-top:32px; }
+  footer .wrap { padding:22px 20px; color:var(--muted); font-size:.9rem; }
+  footer a { color:var(--muted); }
+  @media (max-width:520px) { .hero h1 { font-size:1.7rem; } }
+</style>
+</head>
+<body>
+<header class="top"><div class="wrap"><a href="https://sanskrit-lexicon.github.io/">← Cologne Digital Sanskrit Lexicon</a></div></header>
+<div class="hero"><div class="wrap">
+  <span class="badge">KRM</span>
+  <h1>Kṛdantarūpamālā</h1>
+  <p class="sub">attributed to Bhaṭṭoji Dīkṣita · Madras, 1965–1971</p>
+  <p class="desc">A Sanskrit grammatical handbook of kṛdanta (primary derivative / participial) verb forms, attributed to Bhaṭṭoji Dīkṣita — a systematic reference for Sanskrit verbal derivatives.</p>
+  <div class="cta">
+    <a class="btn primary" href="https://www.sanskrit-lexicon.uni-koeln.de/scans/KRMScan/2020/web/webtc/indexcaller.php">Browse the dictionary →</a>
+    <a class="btn ghost" href="https://github.com/sanskrit-lexicon/KRM">Source &amp; corrections (GitHub)</a>
+    <a class="btn ghost" href="https://sanskrit-lexicon.github.io/">All dictionaries</a>
+  </div>
+</div></div>
+<main><div class="wrap">
+  <dl class="facts">
+    <div><dt>Abbreviation</dt><dd>KRM</dd></div>
+    <div><dt>Direction</dt><dd>Sanskrit → Sanskrit (grammatical)</dd></div>
+    <div><dt>First published</dt><dd>1965</dd></div>
+    <div><dt>Digitised by</dt><dd>CDSL</dd></div>
+  </dl>
+  <section>
+    <h2>About this edition</h2>
+    <p class="note">This is the digital home of the <strong>Kṛdantarūpamālā</strong> (KRM) within the
+    <a href="https://www.sanskrit-lexicon.uni-koeln.de/">Cologne Digital Sanskrit Lexicon</a> (CDSL),
+    a volunteer project that digitises, corrects, and openly publishes the foundational Sanskrit
+    dictionaries as citable, reproducible data. Corrections are tracked as change files in this
+    repository; the searchable text is served on the Cologne site.</p>
+    <h2>Use &amp; reuse</h2>
+    <p class="note">Dictionary data is released under
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless noted otherwise.
+    Report errors or contribute corrections via the
+    <a href="https://github.com/sanskrit-lexicon/KRM/issues">GitHub issue tracker</a>.</p>
+  </section>
+</div></main>
+<footer><div class="wrap">
+  Part of the <a href="https://sanskrit-lexicon.github.io/">Cologne Digital Sanskrit Lexicon</a> ·
+  <a href="https://www.sanskrit-lexicon.uni-koeln.de/">sanskrit-lexicon.uni-koeln.de</a> ·
+  <a href="https://github.com/sanskrit-lexicon">GitHub</a>
+</div></footer>
+</body>
+</html>


### PR DESCRIPTION
Adds an SEO/UX-optimised GitHub Pages landing page (OG meta + JSON-LD Book schema) plus .nojekyll, matching the pattern already live on GRA/MD/PWK/etc. Part of Uprava H260.