### PR TITLE
docs(README): refresh to current facts + org MD conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # KRM — *Kṛdantarūpamālā*
 
-_Created: 31-03-2020 · Last updated: 05-07-2026_
+_Created: 31-03-2020 · Last updated: 11-07-2026_
 
-Development and correction repository for the **_Kṛdantarūpamālā_** (attributed to Bhaṭṭoji Dīkṣita), a Sanskrit grammatical handbook of *kṛdanta* (primary derivative / participial) verb forms, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [`csl-orig/v02/krm/krm.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/krm/krm.txt) (2,061 entries); this repository holds verb-identification and correction work.
+Development and correction repository for the **_Kṛdantarūpamālā_** (attributed to Bhaṭṭoji Dīkṣita), a Sanskrit grammatical handbook of *kṛdanta* (primary derivative / participial) verb forms, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [csl-orig/v02/krm/krm.txt](https://github.com/sanskrit-lexicon/csl-orig/blob/main/v02/krm/krm.txt) (2,061 entries); this repository holds verb-identification and correction work.
 
 ## Documentation
 
-- [CLAUDE.md](CLAUDE.md) — repository guide, correction workflow, and data-format reference.
-- [DATA_DICTIONARY.md](DATA_DICTIONARY.md) — markup tag reference.
-- [CONTRIBUTING.md](CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) · [LICENSE](LICENSE)
+- [CLAUDE.md](https://github.com/sanskrit-lexicon/KRM/blob/main/CLAUDE.md) — repository guide, correction workflow, and data-format reference.
+- [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/KRM/blob/main/DATA_DICTIONARY.md) — markup tag reference.
+- [CONTRIBUTING.md](https://github.com/sanskrit-lexicon/KRM/blob/main/CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](https://github.com/sanskrit-lexicon/KRM/blob/main/CODE_OF_CONDUCT.md) · [LICENSE](https://github.com/sanskrit-lexicon/KRM/blob/main/LICENSE)
 
 ## Contents
 
 | Path | Purpose |
 |---|---|
-| `verbs01/` | Verb-identification: maps KRM roots to MW / Mādhavīya-Dhātuvṛtti headwords |
-| `prefaces/` | Front-matter OCR (title pages, prefaces, forewords, author portrait) of all five volumes, with Russian translations — see [Front matter](#front-matter-prefaces) below |
-| `CITATION.cff` | Machine-readable citation metadata |
-| `DATA_DICTIONARY.md` | Markup tag reference |
+| [verbs01/](https://github.com/sanskrit-lexicon/KRM/tree/main/verbs01) | Verb-identification: maps KRM roots to MW / Mādhavīya-Dhātuvṛtti headwords |
+| [prefaces/](https://github.com/sanskrit-lexicon/KRM/tree/main/prefaces) | Front-matter OCR (title pages, prefaces, forewords, author portrait) of all five volumes, with Russian translations — see [Front matter](#front-matter-prefaces) below |
+| [CITATION.cff](https://github.com/sanskrit-lexicon/KRM/blob/main/CITATION.cff) | Machine-readable citation metadata |
+| [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/KRM/blob/main/DATA_DICTIONARY.md) | Markup tag reference |
 
 ## Timeline
 
@@ -25,7 +25,7 @@ Development and correction repository for the **_Kṛdantarūpamālā_** (attrib
 |---|---|
 | 2020-03 – 2020-04 | Repository initialized; verb-identification work |
 | 2026-05 | Issue taxonomy, citation metadata, documentation |
-| 2026-06 | Front-matter OCR + Russian translation of the prefaces (`prefaces/`) |
+| 2026-06 | Front-matter OCR + Russian translation of the prefaces ([prefaces/](https://github.com/sanskrit-lexicon/KRM/tree/main/prefaces)) |
 
 ## Projects & Milestones
 
@@ -57,15 +57,15 @@ pie showData
 
 | # | Title | Type | Severity | Milestone |
 |---|---|---|---|---|
-| 1 | KRM-MW | content-enhancement | medium | Major Enhancements |
-| 2 | MDP-MW | content-enhancement | medium | Major Enhancements |
-| 3 | krm-mdp-mw | content-enhancement | medium | Major Enhancements |
+| [1](https://github.com/sanskrit-lexicon/KRM/issues/1) | KRM-MW | content-enhancement | medium | Major Enhancements |
+| [2](https://github.com/sanskrit-lexicon/KRM/issues/2) | MDP-MW | content-enhancement | medium | Major Enhancements |
+| [3](https://github.com/sanskrit-lexicon/KRM/issues/3) | krm-mdp-mw | content-enhancement | medium | Major Enhancements |
 
 ### Solved
 
 | # | Title | Type | Severity | Milestone |
 |---|---|---|---|---|
-| 4 | [markup] Minor krm.txt Markup Oddities | markup | minor | Structured Data |
+| [4](https://github.com/sanskrit-lexicon/KRM/issues/4) | [markup] Minor krm.txt Markup Oddities | markup | minor | Structured Data |
 
 ## Labels
 
@@ -93,7 +93,7 @@ pie showData
 
 | Contributor | Commits |
 |---|---|
-| Mārcis Gasūns | 8 |
+| Mārcis Gasūns | 29 |
 | funderburkjim | 4 |
 
 ## Source
@@ -104,7 +104,7 @@ pie showData
 - **Language**: Sanskrit → Sanskrit (grammatical)
 - **Scope**: verb / *kṛdanta* forms only
 - **Entries (digital edition)**: 2,061
-- See [CITATION.cff](CITATION.cff) for machine-readable citation. The repository `LICENSE` and `CITATION.cff` both declare CC BY-SA 4.0.
+- See [CITATION.cff](https://github.com/sanskrit-lexicon/KRM/blob/main/CITATION.cff) for machine-readable citation. The repository [LICENSE](https://github.com/sanskrit-lexicon/KRM/blob/main/LICENSE) and [CITATION.cff](https://github.com/sanskrit-lexicon/KRM/blob/main/CITATION.cff) both declare CC BY-SA 4.0.
 
 ## Encoding
 
@@ -114,7 +114,7 @@ pie showData
 
 ## Usage example
 
-Applying a correction to the real first entry of [`krm.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/krm/krm.txt) with `updateByLine.py` (see root [`CLAUDE.md`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/CLAUDE.md) "Shared correction pattern"). The real current line 8 reads:
+Applying a correction to the real first entry of [`krm.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/v02/krm/krm.txt) with `updateByLine.py` (see root [`CLAUDE.md`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/CLAUDE.md) "Shared correction pattern"). The real current line 8 reads:
 
 ```
 <HI>(1) <s>jaganmAtA parA SaktirBajatAmizwadAyinI .</s>
@@ -136,49 +136,46 @@ This is illustrative only (no such correction is queued) — it shows the real p
 
 ## How it works
 
+Corrections follow the standard CDSL change-file workflow (never edited directly in the source) — see the canonical [correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+
 ```mermaid
 flowchart LR
   S["Print scan (Kṛdantarūpamālā)"] -->|keyboarding| R["raw text"]
   R --> O["csl-orig/v02/krm/krm.txt"]
   O -->|updateByLine.py| C["change_*.txt corrections"]
   C --> O
-  O --> V["verbs01/ root ↔ MW / MDP mapping"]
+  O --> V["verbs01/ root to MW / MDP mapping"]
   O -->|csl-pywork build| X["krm.xml"]
   X --> A["csl-app web display"]
 ```
 
 ## Front matter (`prefaces/`)
 
-The [`prefaces/`](prefaces/) folder holds an OCR of the **front matter** of the *Kṛdantarūpamālā* across all **five volumes** (1965–1971) — title pages, general prefaces, prefaces, forewords, and the author's portrait page — published by the Samskrit Education Society, Madras. The work was begun by *Śāstraratnākara, Kulapati* Pt. **S. Ramasubba Sastri** and completed after his death by his pupils **V. Srivatsankacharya** and **T. K. Pranatartiharan**, under the supervision of Dr. **V. Raghavan**.
+The [prefaces/](https://github.com/sanskrit-lexicon/KRM/tree/main/prefaces) folder holds an OCR of the **front matter** of the *Kṛdantarūpamālā* across all **five volumes** (1965–1971) — title pages, general prefaces, prefaces, forewords, and the author's portrait page — published by the Samskrit Education Society, Madras. The work was begun by *Śāstraratnākara, Kulapati* Pt. **S. Ramasubba Sastri** and completed after his death by his pupils **V. Srivatsankacharya** and **T. K. Pranatartiharan**, under the supervision of Dr. **V. Raghavan**.
 
-- **Source scans** (CDSL csldoc): `https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/krmpref.html`
+- **Source scans** (CDSL csldoc): [krmpref.html](https://sanskrit-lexicon.uni-koeln.de/scans/csldev/csldoc/build/dictionaries/prefaces/krmpref.html)
 - **Source language: English** (two Sanskrit pages — the vol. 1 Sanskrit title and the vol. 5 author-portrait caption/verse — kept verbatim in Devanāgarī). Because the source is English, there is no separate `.en` edition; the base `.md` is the English. Each page also has a Russian translation (`.ru.md`).
 - **24 pages**, all present (all 24 scans on disk; no pages pending).
-- **Consolidated editions:** [`krmpref_all.en.md`](prefaces/krmpref_all.en.md) (source) · [`krmpref_all.ru.md`](prefaces/krmpref_all.ru.md) (Russian), built reproducibly by [`build_combined.py`](prefaces/build_combined.py).
-- **In-folder index:** [`prefaces/README.md`](prefaces/README.md).
+- **Consolidated editions:** [krmpref_all.en.md](https://github.com/sanskrit-lexicon/KRM/blob/main/prefaces/krmpref_all.en.md) (source) · [krmpref_all.ru.md](https://github.com/sanskrit-lexicon/KRM/blob/main/prefaces/krmpref_all.ru.md) (Russian), built reproducibly by [build_combined.py](https://github.com/sanskrit-lexicon/KRM/blob/main/prefaces/build_combined.py).
+- **In-folder index:** [prefaces/README.md](https://github.com/sanskrit-lexicon/KRM/blob/main/prefaces/README.md).
 - **Signatures/dates:** C. P. Ramaswami Aiyar, V. Raghavan, K. Balasubrahmania Iyer (1967, 1968), N. Raghunathan (1971); volume imprints 1965 / 1966 / 1967 / 1968 / 1971.
 - Digitizer running header/footer stamps and library stamps (e.g. Bonn) were omitted as not part of the original.
 
-<details>
-<summary><strong>OCR run notes (2026-06-23)</strong> — cost, timing, and technical lessons</summary>
-
-Produced by the `/cologne-preface-ocr` skill (vision OCR + translation). Process retrospective, not part of the deliverable.
-
-**Context.** Resumed a half-finished job: 24 scans already on disk and pages 01–17 base `.md` already OCR'd by a prior run; no `.ru.md` and no consolidated files existed. The Cologne scan server was down, so this run worked **disk-only** — no downloads.
-
-**Work done this run.** OCR'd the remaining 7 base pages (18–24) from native-resolution crops (≤1900 px bands of the 1892×2834 scans, ≤5 crops/page); wrote Russian translations for **all 24** pages; built the consolidated `*_all.*` editions; wrote the in-folder and root-README indexes.
-
-**Cost (estimate).** Synchronous main-thread run, no subagents. ≈30–35 native-resolution crop reads (7 OCR pages × 3 bands + Devanāgarī tiles) plus 48 page-file writes and 2 combined builds. **Total ≈0.45–0.55 M tokens.**
-
-**Time.** Wall-clock ≈15 min, gated by the per-page crop→read→write loop.
-
-**Technical lessons (reusable):**
-1. Source is **English**, not Sanskrit — only two pages (vol. 1 Sanskrit title, vol. 5 portrait caption/verse) are Devanāgarī. So `.en` is skipped and the source-base files are the English text; the consolidated source edition is tagged `.en`.
-2. `build_combined.py`'s page glob `krmpref[0-9][0-9].md` correctly matches the real `krmprefNN.md` filenames (no `krmNN.md` mismatch here) — verified before building.
-3. A Sanskrit `# heading` quoted **inside** a page body (vol. 1 Sanskrit title in `krmpref02.ru.md`) became a stray top-level `##` after the builder's heading-demotion, inflating the H2 count to 26. Fixed by demoting that inner heading to `##` in the source so it lands at `###`. H2 count is now exactly 25 (1 TOC + 24 pages) in both editions.
-4. The portrait page (24) needed a separate 3× Devanāgarī crop of the caption and benedictory verse to read the conjuncts reliably.
-
-</details>
+> **OCR run notes (2026-06-23)** — cost, timing, and technical lessons. Produced by the `/cologne-preface-ocr` skill (vision OCR + translation). Process retrospective, not part of the deliverable.
+>
+> **Context.** Resumed a half-finished job: 24 scans already on disk and pages 01–17 base `.md` already OCR'd by a prior run; no `.ru.md` and no consolidated files existed. The Cologne scan server was down, so this run worked **disk-only** — no downloads.
+>
+> **Work done this run.** OCR'd the remaining 7 base pages (18–24) from native-resolution crops (≤1900 px bands of the 1892×2834 scans, ≤5 crops/page); wrote Russian translations for **all 24** pages; built the consolidated `*_all.*` editions; wrote the in-folder and root-README indexes.
+>
+> **Cost (estimate).** Synchronous main-thread run, no subagents. ≈30–35 native-resolution crop reads (7 OCR pages × 3 bands + Devanāgarī tiles) plus 48 page-file writes and 2 combined builds. **Total ≈0.45–0.55 M tokens.**
+>
+> **Time.** Wall-clock ≈15 min, gated by the per-page crop→read→write loop.
+>
+> **Technical lessons (reusable):**
+> 1. Source is **English**, not Sanskrit — only two pages (vol. 1 Sanskrit title, vol. 5 portrait caption/verse) are Devanāgarī. So `.en` is skipped and the source-base files are the English text; the consolidated source edition is tagged `.en`.
+> 2. `build_combined.py`'s page glob `krmpref[0-9][0-9].md` correctly matches the real `krmprefNN.md` filenames (no `krmNN.md` mismatch here) — verified before building.
+> 3. A Sanskrit `# heading` quoted **inside** a page body (vol. 1 Sanskrit title in `krmpref02.ru.md`) became a stray top-level `##` after the builder's heading-demotion, inflating the H2 count to 26. Fixed by demoting that inner heading to `##` in the source so it lands at `###`. H2 count is now exactly 25 (1 TOC + 24 pages) in both editions.
+> 4. The portrait page (24) needed a separate 3× Devanāgarī crop of the caption and benedictory verse to read the conjuncts reliably.
 
 ---
 *Issue taxonomy and documentation per the [Cologne issue runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-issue-runbook.md).*


### PR DESCRIPTION
Delivers the stalled `readme-refresh-h548` readme-refresh branch (H548/H549/H550 initiative) found stranded/unpushed by /dirty-tree-sweep (H799). Single-file README.md refresh, no code changes.